### PR TITLE
feat: Map menu actions to standard symbolic icons with flatpak and generic fallbacks

### DIFF
--- a/applet/src/app.rs
+++ b/applet/src/app.rs
@@ -126,27 +126,49 @@ impl Application for LogoMenu {
         for item in &config_menuitems.items {
             match item.item_type() {
                 MenuItemType::LaunchAction => {
-                    content_list = content_list.push(
-                        menu_button(widget::text::body(item.label().unwrap_or_default()))
-                            .on_press(Message::Run(item.command().unwrap_or_default())),
-                    )
+                    let command = item.command().unwrap_or_default();
+                    let label = item.label().unwrap_or_default();
+                    let icon_name = get_icon_for_action(&command);
+
+                    let action_content = widget::row([])
+                        .push(cosmic::widget::icon::from_name(icon_name).size(16))
+                        .push(widget::text::body(label))
+                        .spacing(8)
+                        .align_y(cosmic::iced::Alignment::Center);
+
+                    content_list = content_list
+                        .push(menu_button(action_content).on_press(Message::Run(command)))
                 }
                 MenuItemType::PowerAction => {
-                    content_list = content_list.push(
-                        menu_button(widget::text::body(item.label().unwrap_or_default())).on_press(
-                            Message::Action(match item.command() {
-                                Some(command) => match command.as_ref() {
-                                    "Lock" => PowerAction::Lock,
-                                    "Logout" => PowerAction::LogOut,
-                                    "Suspend" => PowerAction::Suspend,
-                                    "Restart" => PowerAction::Restart,
-                                    "Shutdown" => PowerAction::Shutdown,
-                                    _ => PowerAction::LogOut,
-                                },
-                                _ => PowerAction::Shutdown,
-                            }),
-                        ),
-                    )
+                    let command = item.command().unwrap_or_default();
+                    let label = item.label().unwrap_or_default();
+
+                    let icon_name = match command.as_str() {
+                        "Lock" => "system-lock-screen-symbolic",
+                        "Logout" => "system-log-out-symbolic",
+                        "Suspend" => "system-suspend-symbolic",
+                        "Restart" => "system-reboot-symbolic",
+                        "Shutdown" => "system-shutdown-symbolic",
+                        _ => "system-shutdown-symbolic",
+                    };
+
+                    let action_content = widget::row([])
+                        .push(cosmic::widget::icon::from_name(icon_name).size(16))
+                        .push(widget::text::body(label))
+                        .spacing(8)
+                        .align_y(cosmic::iced::Alignment::Center);
+
+                    content_list = content_list.push(menu_button(action_content).on_press(
+                        Message::Action(match command.as_str() {
+                            "Lock" => PowerAction::Lock,
+                            "Logout" => PowerAction::LogOut,
+                            "Suspend" => PowerAction::Suspend,
+                            "Restart" => PowerAction::Restart,
+                            "Shutdown" => PowerAction::Shutdown,
+                            "" => PowerAction::Shutdown,
+                            _ => PowerAction::LogOut,
+                        }),
+                    ))
                 }
                 MenuItemType::Divider => {
                     content_list = content_list.push(
@@ -291,4 +313,38 @@ fn is_flatpak() -> bool {
 
 fn is_nixos() -> bool {
     fs::exists("/run/host/etc/NIXOS").unwrap_or(false)
+}
+
+fn get_icon_for_action(command: &str) -> &str {
+    let cmd = command.to_lowercase();
+
+    // 1. Ecossistema COSMIC & Padrões FreeDesktop
+    if cmd.contains("logomenu-settings") {
+        return "preferences-other-symbolic";
+    } else if cmd.contains("cosmic-launcher") {
+        return "system-search-symbolic";
+    } else if cmd.contains("cosmic-app-library") || cmd.contains("app-library") {
+        return "view-app-grid-symbolic";
+    } else if cmd.contains("cosmic-workspaces") {
+        return "preferences-desktop-workspaces-symbolic";
+    } else if cmd.contains("cosmic-settings") || cmd.contains("control-center") {
+        return "preferences-system-symbolic";
+    } else if cmd.contains("cosmic-files") || cmd.contains("nautilus") {
+        return "system-file-manager-symbolic";
+    } else if cmd.contains("cosmic-term") || cmd.contains("terminal") || cmd.contains("kitty") {
+        return "utilities-terminal-symbolic";
+    } else if cmd.contains("cosmic-store") || cmd.contains("software") {
+        return "system-software-install-symbolic";
+    }
+
+    // 2. Extração para Flatpaks (Alta taxa de sucesso de achar o ícone colorido oficial)
+    if command.starts_with("flatpak run ") {
+        if let Some(app_id) = command.split_whitespace().nth(2) {
+            return app_id;
+        }
+    }
+
+    // 3. Fallback Absoluto e Garantido
+    // Qualquer script customizado ou comando desconhecido receberá este ícone.
+    "system-run-symbolic"
 }

--- a/applet/src/app.rs
+++ b/applet/src/app.rs
@@ -128,8 +128,11 @@ impl Application for LogoMenu {
                 MenuItemType::LaunchAction => {
                     let command = item.command().unwrap_or_default();
                     let label = item.label().unwrap_or_default();
+
+                    // Fetch the appropriate icon (system, flatpak, or fallback)
                     let icon_name = get_icon_for_action(&command);
 
+                    // Build the button content with icon and text side-by-side
                     let action_content = widget::row([])
                         .push(cosmic::widget::icon::from_name(icon_name).size(16))
                         .push(widget::text::body(label))
@@ -142,7 +145,8 @@ impl Application for LogoMenu {
                 MenuItemType::PowerAction => {
                     let command = item.command().unwrap_or_default();
                     let label = item.label().unwrap_or_default();
-
+                    
+                    // Map power actions to standard FreeDesktop symbolic icons
                     let icon_name = match command.as_str() {
                         "Lock" => "system-lock-screen-symbolic",
                         "Logout" => "system-log-out-symbolic",
@@ -152,6 +156,7 @@ impl Application for LogoMenu {
                         _ => "system-shutdown-symbolic",
                     };
 
+                    // Build the button content with icon and text side-by-side
                     let action_content = widget::row([])
                         .push(cosmic::widget::icon::from_name(icon_name).size(16))
                         .push(widget::text::body(label))
@@ -318,7 +323,7 @@ fn is_nixos() -> bool {
 fn get_icon_for_action(command: &str) -> &str {
     let cmd = command.to_lowercase();
 
-    // 1. Ecossistema COSMIC & Padrões FreeDesktop
+    // 1. COSMIC Ecosystem & FreeDesktop Standards
     if cmd.contains("logomenu-settings") {
         return "preferences-other-symbolic";
     } else if cmd.contains("cosmic-launcher") {
@@ -337,14 +342,14 @@ fn get_icon_for_action(command: &str) -> &str {
         return "system-software-install-symbolic";
     }
 
-    // 2. Extração para Flatpaks (Alta taxa de sucesso de achar o ícone colorido oficial)
+    // 2. Flatpak Extraction (High success rate for fetching official colorful app icons)
     if command.starts_with("flatpak run ") {
         if let Some(app_id) = command.split_whitespace().nth(2) {
             return app_id;
         }
     }
 
-    // 3. Fallback Absoluto e Garantido
-    // Qualquer script customizado ou comando desconhecido receberá este ícone.
+    // 3. Absolute Fallback
+    // Custom scripts or unknown commands will receive a generic execution icon.
     "system-run-symbolic"
 }


### PR DESCRIPTION
Currently, the menu applet displays only text for most actions, which deviates from the COSMIC Human Interface Guidelines.
This PR updates the UI rendering and implements the `get_icon_for_action` function to dynamically assign icons:
1. Refactors the `view_window` rendering logic to use `widget::row`, placing the dynamically fetched icon alongside the action label.
2. Maps standard system actions (launcher, settings, files, workspaces) to their respective FreeDesktop/COSMIC `-symbolic` icons.
3. Maps native `PowerAction` items directly to standard power/session `-symbolic` icons.
4. Extracts the App ID for Flatpak commands to automatically fetch their official colorful RDNS icons.
5. Uses `system-run-symbolic` as a definitive fallback to ensure no menu item is rendered with an empty space.

> *Note: The logic for this implementation was co-authored with the assistance of an AI, strictly adhering to FreeDesktop and COSMIC ecosystem standards.*

**<img width="562" height="716" alt="Screenshot_2026-07-26_22-08-00" src="https://github.com/user-attachments/assets/5a3d66ba-8e36-4d7c-8c5e-20fd7852d8eb" />**