### PR TITLE
cosmic-config repo no longer existing

### DIFF
--- a/liblog/Cargo.toml
+++ b/liblog/Cargo.toml
@@ -8,7 +8,6 @@ edition = "2024"
 rust-embed = "8.12.0"
 phf = { version = "0.14.0", "features" = ["macros"] }
 serde = "1.0.229"
-cosmic-config = { git = "https://github.com/pop-os/libcosmic" }
 
 [dependencies.i18n-embed]
 version = "0.16.0"


### PR DESCRIPTION
Removed cosmic-config as the repo either has been renamed or it just doesn't exist anymore. Feel free to fix this if I made this in error.